### PR TITLE
Select the BSP_ID.m file, rather than the folder.

### DIFF
--- a/src/UI/Preferences/kVIS_preferencesBspChange.m
+++ b/src/UI/Preferences/kVIS_preferencesBspChange.m
@@ -32,7 +32,8 @@ function kVIS_preferencesBspChange(~, ~)
 % change BSP directory
 %
 
-bspDir = uigetdir();
+%bspDir = uigetdir();
+[~,bspDir,~] = uigetfile('BSP_ID.m','Select BSP_ID.m File','BSP_ID.m');
 
 if bspDir == 0
     return


### PR DESCRIPTION
Seems more natural to me to have it this way (selecting a file rather than a folder).  If you prefer the old way, feel free to delete :)